### PR TITLE
Remove space before wp-settings.php and return string, not boolean.

### DIFF
--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -120,11 +120,11 @@ class Install_Command extends Command {
 					throw new RuntimeException( 'Directory not found.' );
 				}
 
-				if ( ! file_exists( $dir . ' /wp-settings.php' ) ) {
+				if ( ! file_exists( $dir . '/wp-settings.php' ) ) {
 					throw new RuntimeException( 'Invalid WordPress installation.' );
 				}
 
-				return true;
+				return $dir;
 			}
 		);
 	}

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -115,6 +115,12 @@ class Install_Command extends Command {
 		return $style->ask(
 			'Please specify your WordPress installation:',
 			null,
+			/**
+			 * Callback function that handles validating the manually defined WordPress installation directory.
+			 * 
+			 * @param string $dir The full path to the WordPress directory, as defined by the user.
+			 * @return string $dir The path as passed by the user, after passing validation.
+			 */
 			function ( $dir ) {
 				if ( ! is_dir( $dir ) ) {
 					throw new RuntimeException( 'Directory not found.' );


### PR DESCRIPTION
Returning a boolean at this point causes `$dir` to evaluate to `1` in `install_mantle`. This change causes it to return the approved directory, as expected.

Also it fixes a typo that caused the `/wp-settings.php` evaluation to never evaluate to true.