### PR TITLE
Make mantle installer work with the default Homestead WP environment

### DIFF
--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -99,7 +99,7 @@ class Install_Command extends Command {
 			is_dir( $abspath . '/wp/' ) &&
 			file_exists( $abspath . '/wp/wp-settings.php' )
 		) {
-			$output->writeln( "Using [<pg=yellow>{$abspath}</fg=yellow>] as the WordPress installation." );
+			$output->writeln( "Using [<fg=yellow>{$abspath}/wp/</fg=yellow>] as the WordPress installation, and [<fg=yellow>{$abspath}/wp-content/</fg=yellow>] as the WP Content directory." );
 			return $abspath;
 		}
 

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -93,6 +93,16 @@ class Install_Command extends Command {
 			return $abspath;
 		}
 
+		// Check if we are inside of the default Homestead WordPress environement.
+		if (
+			is_dir( $abspath . '/wp-content/' ) &&
+			is_dir( $abspath . '/wp/' ) &&
+			file_exists( $abspath . '/wp/wp-settings.php' )
+		) {
+			$output->writeln( "Using [<pg=yellow>{$abspath}</fg=yellow>] as the WordPress installation." );
+			return $abspath;
+		}
+
 		$style = new SymfonyStyle( $input, $output );
 
 		// Bail if the folder already exists.
@@ -107,7 +117,7 @@ class Install_Command extends Command {
 		}
 
 		// Ask the user if we should be installing.
-		if ( $style->confirm( "Would you like to install WordPress at [<fg=yellow>{$abspath}</>]", true ) ) {
+		if ( $style->confirm( "Would you like to install WordPress at [<fg=yellow>{$abspath}</fg=yellow>]", true ) ) {
 			$this->install_wordpress( $abspath, $input, $output );
 			return $abspath;
 		}


### PR DESCRIPTION
Just as the title suggests, this adds a check in `get_wordpress_root` that looks for the structure of the default Homestead install, which installs WordPress in a `/wp/` directory, `wp-config.php` in the root, and `/wp-content` in the root.