### PR TITLE
Remove wp-cli dependency/fix installation error

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,48 +2,12 @@ name: Coding Standards
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        php: [7.4]
-    name: PHP ${{ matrix.php }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ matrix.php }}-composer-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
-          tools: composer:v2
-          coverage: none
-      - name: Validate Composer
-        run: composer validate --strict
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer install
-      - name: Run phpcs
-        run: composer run phpcs
+  coding-standards:
+    uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,45 +2,19 @@ name: Testing Suite
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  php-tests:
     strategy:
-      fail-fast: true
       matrix:
         php: [7.4, 8.0]
-    name: PHP ${{ matrix.php }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Set up Composer caching
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ matrix.php }}-composer-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
-          tools: composer:v2
-          coverage: none
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer install
-      - name: Run phpunit
-        run: composer run phpunit
+        wordpress: ["latest"]
+    uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
+    with:
+      php: ${{ matrix.php }}
+      wordpress: ${{ matrix.wordpress }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,6 +2,8 @@ name: Testing Suite
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,42 +9,12 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  php-tests:
     strategy:
-      fail-fast: true
       matrix:
         php: [7.4, 8.0]
-    name: PHP ${{ matrix.php }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: true
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Set up Composer caching
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ matrix.php }}-composer-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
-          tools: composer:v2
-          coverage: none
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer install
-      - name: Run phpunit
-        run: composer run phpunit
+        wordpress: ["latest"]
+    uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
+    with:
+      php: ${{ matrix.php }}
+      wordpress: ${{ matrix.wordpress }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,12 +17,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
+      - name: Setup SSH Keys and known_hosts
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,19 +2,51 @@ name: Testing Suite
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  php-tests:
+  tests:
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
         php: [7.4, 8.0]
-        wordpress: ["latest"]
-    uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
-    with:
-      php: ${{ matrix.php }}
-      wordpress: ${{ matrix.wordpress }}
+    name: PHP ${{ matrix.php }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Set up Composer caching
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-composer-dependencies
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ matrix.php }}-composer-
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          tools: composer:v2
+          coverage: none
+      - name: Install dependencies
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer install
+      - name: Run phpunit
+        run: composer run phpunit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,14 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup SSH Keys and known_hosts
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+        with:
+          persist-credentials: true
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 composer.lock
 .phpunit.result.cache
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,7 @@
   "require": {
     "php": "^7.4|^8.0",
     "symfony/console": "^5.0",
-    "symfony/process": "^5.0",
-    "wp-cli/core-command": "^2.0",
-    "wp-cli/wp-cli": "^2.4"
+    "symfony/process": "^5.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3",
@@ -37,6 +35,10 @@
   ],
   "scripts": {
     "phpcs": "phpcs --standard=./phpcs.xml .",
-    "phpunit": "phpunit"
+    "phpunit": "phpunit",
+    "test": [
+      "@phpcs",
+      "@phpunit"
+    ]
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,5 +6,7 @@
 
 	<rule ref="Alley-Interactive">
 		<exclude name="WordPress.WP.AlternativeFunctions" />
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure" />
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals" />
 	</rule>
 </ruleset>

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -2,8 +2,6 @@
 /**
  * Install_Command class file.
  *
- * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals, Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
- *
  * @package Mantle
  */
 

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -2,7 +2,7 @@
 /**
  * Install_Command class file.
  *
- * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals, Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
  *
  * @package Mantle
  */
@@ -179,21 +179,27 @@ class Install_Command extends Command {
 	 * @return string
 	 */
 	protected function find_wp_cli(): string {
+		// Check if the wp-cli path was set in an environment variable.
+		if ( $wp_cli = getenv( 'WP_CLI_PATH' ) ) {
+			return $wp_cli;
+		}
+
 		$path = getcwd() . '/wp-cli.phar';
 
 		if ( file_exists( $path ) ) {
 			return '"' . PHP_BINARY . '" ' . $path;
 		}
 
-		$paths = [
-			__DIR__ . '/../vendor/wp-cli/wp-cli/bin/wp',
-			__DIR__ . '/../../../wp-cli/wp-cli/bin/wp',
-		];
+		// Check if wp-cli is installed globally.
+		$path = exec( 'which wp' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 
-		foreach ( $paths as $path ) {
-			if ( file_exists( $path ) ) {
-				return $path;
-			}
+		if ( $path ) {
+			return $path;
+		}
+
+		// Fallback to the one installed with the package.
+		if ( file_exists( __DIR__ . '/../bin/wp-cli.phar' ) ) {
+			return '"' . PHP_BINARY . '" ' . __DIR__ . '/../bin/wp-cli.phar';
 		}
 
 		return 'wp';
@@ -205,6 +211,11 @@ class Install_Command extends Command {
 	 * @return string
 	 */
 	protected function find_composer(): string {
+		// Check if the composer path was set in an environment variable.
+		if ( $composer = getenv( 'COMPOSER_PATH' ) ) {
+			return $composer;
+		}
+
 		$composer_path = getcwd() . '/composer.phar';
 
 		if ( file_exists( $composer_path ) ) {

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -28,11 +28,11 @@ class Install_Command extends Command {
 		$this->setName( 'new' )
 			->setDescription( 'Create a new Mantle application' )
 			->addArgument( 'name', InputOption::VALUE_OPTIONAL, 'Name of the folder to install WordPress in, optional.', null )
-			->addOption( 'dev', null, InputOption::VALUE_NONE, 'Installs the latest "development" release' )
 			->addOption( 'force', 'f', InputOption::VALUE_NONE, 'Install even if the directory already exists' )
 			->addOption( 'install', 'i', InputOption::VALUE_NONE, 'Install WordPress in the current location if it doesn\'t exist.' )
 			->addOption( 'no-must-use', 'no-mu', InputOption::VALUE_OPTIONAL, 'Don\'t load Mantle as a must-use plugin.', false )
-			->addOption( 'setup-dev', null, InputOption::VALUE_NONE, 'Setup mantle for development on the framework.' );
+			->addOption( 'dev', 'd', InputOption::VALUE_NONE, 'Setup mantle for development on the framework.' )
+			->addOption( 'setup-dev', null, InputOption::VALUE_NONE, '(Legacy) setup mantle for development on the framework.' );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class Install_Command extends Command {
 		];
 
 		// Setup the application for local development on the framework.
-		if ( $input->getOption( 'setup-dev' ) ) {
+		if ( $input->getOption( 'dev' ) || $input->getOption( 'setup-dev' ) ) {
 			if ( is_dir( $framework_dir ) && file_exists( "{$framework_dir}/composer.json" ) ) {
 				throw new RuntimeException( "Mantle Framework is already installed: [{$framework_dir}'" );
 			}
@@ -289,6 +289,8 @@ class Install_Command extends Command {
 				"cd {$framework_dir} && composer install",
 				"git clone git@github.com:alleyinteractive/mantle.git {$mantle_dir}",
 				"cd {$mantle_dir} && composer config repositories.mantle-framework '{\"type\": \"path\", \"url\": \"../{$name}-framework\", \"options\": {\"symlink\": true}}' --file composer.json",
+				// Update Mantle to accept any version of these dependencies.
+				"cd {$mantle_dir} && composer require alleyinteractive/mantle-framework:\"*\" alleyinteractive/composer-wordpress-autoloader:\"*\" --no-update --no-scripts",
 				"cd {$mantle_dir} && composer install --no-scripts",
 			];
 		}

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -288,7 +288,8 @@ class Install_Command extends Command {
 				"git clone https://github.com/alleyinteractive/mantle-framework.git {$framework_dir}",
 				"cd {$framework_dir} && git remote set-url origin git@github.com:alleyinteractive/mantle-framework.git",
 				"cd {$framework_dir} && composer install",
-				"git clone git@github.com:alleyinteractive/mantle.git {$mantle_dir}",
+				"git clone https://github.com/alleyinteractive/mantle.git {$mantle_dir}",
+				"cd {$framework_dir} && git remote set-url origin git@github.com:alleyinteractive/mantle.git",
 				"cd {$mantle_dir} && composer config repositories.mantle-framework '{\"type\": \"path\", \"url\": \"../{$name}-framework\", \"options\": {\"symlink\": true}}' --file composer.json",
 				// Update Mantle to accept any version of these dependencies.
 				"cd {$mantle_dir} && composer require alleyinteractive/mantle-framework:\"*\" alleyinteractive/composer-wordpress-autoloader:\"*\" --no-update --no-scripts",

--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -285,7 +285,8 @@ class Install_Command extends Command {
 			}
 
 			$commands = [
-				"git clone git@github.com:alleyinteractive/mantle-framework.git {$framework_dir}",
+				"git clone https://github.com/alleyinteractive/mantle-framework.git {$framework_dir}",
+				"cd {$framework_dir} && git remote set-url origin git@github.com:alleyinteractive/mantle-framework.git",
 				"cd {$framework_dir} && composer install",
 				"git clone git@github.com:alleyinteractive/mantle.git {$mantle_dir}",
 				"cd {$mantle_dir} && composer config repositories.mantle-framework '{\"type\": \"path\", \"url\": \"../{$name}-framework\", \"options\": {\"symlink\": true}}' --file composer.json",

--- a/tests/test-install-command.php
+++ b/tests/test-install-command.php
@@ -8,12 +8,22 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Throwable;
 
 class Test_Install_Command extends TestCase {
-	public function test_install_wordpress() {
+	protected function setUp(): void {
+		parent::setUp();
+
 		$output = __DIR__ . '/output';
 
 		if ( is_dir( $output . '/new-site' ) ) {
 			exec( 'rm -rf ' . $output . '/new-site' );
 		}
+
+		if ( is_dir( $output . '/new-site-dev' ) ) {
+			exec( 'rm -rf ' . $output . '/new-site-dev' );
+		}
+	}
+
+	public function test_install_wordpress() {
+		$output = __DIR__ . '/output';
 
 		chdir( $output );
 
@@ -43,10 +53,6 @@ class Test_Install_Command extends TestCase {
 
 	public function test_install_wordpress_dev() {
 		$output = __DIR__ . '/output';
-
-		if ( is_dir( $output . '/new-site-dev' ) ) {
-			exec( 'rm -rf ' . $output . '/new-site-dev' );
-		}
 
 		chdir( $output );
 

--- a/tests/test-install-command.php
+++ b/tests/test-install-command.php
@@ -41,6 +41,44 @@ class Test_Install_Command extends TestCase {
 		$this->assertFileExists( "{$output}/new-site/wp-content/mu-plugins/new-site-loader.php" );
 	}
 
+	public function test_install_wordpress_dev() {
+		$output = __DIR__ . '/output';
+
+		if ( is_dir( $output . '/new-site-dev' ) ) {
+			exec( 'rm -rf ' . $output . '/new-site-dev' );
+		}
+
+		chdir( $output );
+
+		$tester = $this->get_tester();
+
+		try {
+			$status_code = $tester->execute(
+				[
+					'name' => [ 'new-site-dev' ],
+					'--install' => true,
+					'--force' => true,
+					'--dev' => true,
+				],
+				[
+					'i',
+					'f',
+					'd',
+				]
+			);
+		} catch ( Throwable $e ) {
+			echo $tester->getDisplay( true );
+			throw $e;
+		}
+
+		$this->assertEquals( 0, $status_code );
+		$this->assertDirectoryExists( "{$output}/new-site-dev" );
+		$this->assertFileExists( "{$output}/new-site-dev/wp-settings.php" );
+		$this->assertFileExists( "{$output}/new-site-dev/wp-content/plugins/new-site-dev/mantle.php" );
+		$this->assertFileExists( "{$output}/new-site-dev/wp-content/plugins/new-site-dev-framework/composer.json" );
+		$this->assertFileExists( "{$output}/new-site-dev/wp-content/mu-plugins/new-site-dev-loader.php" );
+	}
+
 	protected function get_tester(): CommandTester {
 		$app = new Application( 'Mantle Installer' );
 		$app->add( new Install_Command() );


### PR DESCRIPTION
- Remove the dependency on `wp-cli` to not override the global `wp` command.
- Fix installation when `--dev` is passed and `alleyinteractive/mantle` and `alleyinteractive/mantle-framework` have differing versions.