### PR TITLE
Update wpcom_vip_load_plugin call so it will load

### DIFF
--- a/src/class-install-command.php
+++ b/src/class-install-command.php
@@ -353,7 +353,7 @@ class Install_Command extends Command {
 */
 
 if ( function_exists( 'wpcom_vip_load_plugin' ) ) {
-	wpcom_vip_load_plugin( '$plugin_name' );
+	wpcom_vip_load_plugin( '$plugin_name/mantle.php' );
 } else {
 	require_once WP_CONTENT_DIR . '/plugins/$plugin_name/mantle.php';
 }


### PR DESCRIPTION
This fixes the call to `wpcom_vip_load_plugin` to reference the `mantle.php` file, so it doesn't throw an error when used to load the plugin.